### PR TITLE
set debug as False

### DIFF
--- a/app.py
+++ b/app.py
@@ -152,5 +152,5 @@ socketio.run(
     app,
     host=os.getenv('IP', '0.0.0.0'),
     port=int(os.getenv('PORT', 8081)),
-    debug=True
+    debug=False
 )


### PR DESCRIPTION
setting debug as true in production exposes the Werkzeug debugger and allows the execution of arbitrary code